### PR TITLE
Fix 'no tests found' by running `yarn test(:js)`

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,9 +95,7 @@
       "es6",
       "js"
     ],
-    "testMatch": [
-      "**/__tests__/**/*.es6"
-    ],
+    "testRegex": ".*\\.test\\.es6$",
     "roots": [
       "<rootDir>/src/js/"
     ],


### PR DESCRIPTION
## 概要

`yarn test:js` で jestが期待するテストファイルを見つけてくれず、 no tests foundといわれるので